### PR TITLE
adds pnmlwriter test helper script

### DIFF
--- a/snippets/parse_and_export_pnml.sh
+++ b/snippets/parse_and_export_pnml.sh
@@ -1,0 +1,6 @@
+MCC_FOLDER = $1
+BINARY = $2
+for MODEL in $(ls $MCC_FOLDER) ; do
+  ./$BINARY -R 0 -x 1 $MCC_FOLDE/$MODEL/model.pnml $MCC_FOLDE/$MODEL/ReachabilityCardinality.xml  --write-col-reduced $MCC_FOLDE/$MODEL/model.pnml --nounfold -n
+	echo "Parsed and exported $MODEL pnml file"
+done


### PR DESCRIPTION
Parses and exports all models in the given folder, without any reduction or unfolding. Used to test if the exported models in the Pnmlwriter is consistent with original models